### PR TITLE
Auto batch size

### DIFF
--- a/src/eval/evaluate.py
+++ b/src/eval/evaluate.py
@@ -164,7 +164,7 @@ def get_model(
 
     return model.to(DEVICE)
 
-@auto_batch_size()
+@auto_batch_size(max_batch_size=128)
 def compute_kshot_metrics(
     dataset_path,
     category,

--- a/src/eval/evaluate.py
+++ b/src/eval/evaluate.py
@@ -20,6 +20,7 @@ from torchvision.transforms.v2 import Resize
 from tqdm import tqdm
 
 from eval.submission.model import Model
+from eval.utils import auto_batch_size
 
 CATEGORIES = [
     "breakfast_box",
@@ -163,13 +164,14 @@ def get_model(
 
     return model.to(DEVICE)
 
-
+@auto_batch_size()
 def compute_kshot_metrics(
-    train_dataset: MVTecLOCODataset,
-    test_dataloader: DataLoader,
+    dataset_path,
+    category,
     model: nn.Module,
     k_shot: int,
     seed: int,
+    batch_size: int | None = None,
 ) -> dict[str, float]:
     """Compute metrics for a specific k-shot setting.
 
@@ -183,6 +185,9 @@ def compute_kshot_metrics(
     Returns:
         dict[str, float]: Computed metrics for this k-shot setting.
     """
+    train_dataloader, test_dataloader = get_dataloaders(dataset_path, category, batch_size=batch_size)
+    train_dataset = cast(MVTecLOCODataset, train_dataloader.dataset)  # Get underlying dataset)
+
     image_metric = _F1Max().to(DEVICE)
 
     # Sample k_shot images from the training set deterministically
@@ -271,26 +276,27 @@ def evaluate_submission(
     Returns:
         dict[str, float]: Final averaged metrics.
     """
+
     metrics = []
     print(f"Using device: {DEVICE}")
+
+    # create dictso that we only compute batch size once per k_shot
+    batch_size_dict = {k_shot: None for k_shot in k_shots}
 
     for category in tqdm(CATEGORIES, desc="Processing Categories"):
         # --- Per-Category Setup ---
         # Load model once per category
         model = get_model(category)
-        # Load data once per category
-        train_dataloader, test_dataloader = get_dataloaders(dataset_path, category, batch_size=model.batch_size)
-        train_dataset = cast(MVTecLOCODataset, train_dataloader.dataset)  # Get underlying dataset
-
         for seed in tqdm(seeds, desc=f"Category {category} Seeds", leave=False):
             for k_shot in k_shots:  # No tqdm here, handled in compute_kshot_metrics
                 # Compute metrics for this specific seed/category/k-shot combination
-                k_shot_metrics = compute_kshot_metrics(
-                    train_dataset=train_dataset,
-                    test_dataloader=test_dataloader,
+                k_shot_metrics, batch_size = compute_kshot_metrics(
+                    dataset_path,
+                    category,
                     model=model,
                     k_shot=k_shot,
                     seed=seed,
+                    batch_size=batch_size_dict[k_shot],
                 )
 
                 # Append results
@@ -302,6 +308,9 @@ def evaluate_submission(
                         "image_score": k_shot_metrics["image_score"],
                     }
                 )
+
+                # update batch size dict
+                batch_size_dict[k_shot] = batch_size
 
     final_average_metrics = compute_average_metrics(metrics)
     print("Final Average Metrics Across All Seeds:", final_average_metrics)

--- a/src/eval/submission/model.py
+++ b/src/eval/submission/model.py
@@ -26,12 +26,6 @@ class Model(nn.Module):
         # TODO: Implement this if you want to download the weights from a URL
         return None
 
-    @property
-    def batch_size(self) -> int:
-        """Batch size of the model."""
-        # TODO: Reduce the batch size in case your model is too large to fit in memory.
-        return 32
-
     def forward(self, image: torch.Tensor) -> ImageBatch:
         """Forward pass of the model.
 

--- a/src/eval/utils.py
+++ b/src/eval/utils.py
@@ -1,0 +1,40 @@
+import functools
+import torch
+
+def ispow2(n):
+    return n > 0 and (n & (n - 1)) == 0
+
+def auto_batch_size(max_batch_size=1024, min_batch_size=1):
+    """
+    Decorator that retries the function with decreasing powers of two as batch size
+    on OOM errors. Validates that starting_batch_size is a power of two.
+    """
+    if not ispow2(max_batch_size):
+        raise ValueError(f"starting_batch_size must be a power of 2, got {max_batch_size}")
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            if kwargs.get('batch_size') is not None:
+                # when passed explicitly, we don't auto-configure the batch size
+                print("Using pre-specified batch size:", kwargs['batch_size'])
+                return fn(*args, **kwargs), kwargs['batch_size']
+            batch_size = max_batch_size
+            while batch_size >= min_batch_size:
+                try:
+                    print(f"Trying with batch size {batch_size}")
+                    torch.cuda.empty_cache()
+                    kwargs["batch_size"] = batch_size
+                    result = fn(*args, **kwargs)
+                    print(f"Success with batch size: {batch_size}")
+                    return result, batch_size
+                except RuntimeError as e:
+                    if 'out of memory' in str(e).lower():
+                        print(f"OOM at batch size {batch_size}, trying smaller...")
+                        torch.cuda.empty_cache()
+                        batch_size //= 2
+                    else:
+                        raise e
+            raise RuntimeError(f"All batch sizes down to {min_batch_size} caused OOM.")
+        return wrapper
+    return decorator

--- a/src/eval/utils.py
+++ b/src/eval/utils.py
@@ -4,7 +4,7 @@ import torch
 def ispow2(n):
     return n > 0 and (n & (n - 1)) == 0
 
-def auto_batch_size(max_batch_size=1024, min_batch_size=1):
+def auto_batch_size(max_batch_size=128, min_batch_size=1):
     """
     Decorator that retries the function with decreasing powers of two as batch size
     on OOM errors. Validates that starting_batch_size is a power of two.
@@ -17,24 +17,24 @@ def auto_batch_size(max_batch_size=1024, min_batch_size=1):
         def wrapper(*args, **kwargs):
             if kwargs.get('batch_size') is not None:
                 # when passed explicitly, we don't auto-configure the batch size
-                print("Using pre-specified batch size:", kwargs['batch_size'])
+                print("\nUsing pre-specified batch size:", kwargs['batch_size'])
                 return fn(*args, **kwargs), kwargs['batch_size']
             batch_size = max_batch_size
             while batch_size >= min_batch_size:
                 try:
-                    print(f"Trying with batch size {batch_size}")
+                    print(f"\nTrying with batch size {batch_size}")
                     torch.cuda.empty_cache()
                     kwargs["batch_size"] = batch_size
                     result = fn(*args, **kwargs)
-                    print(f"Success with batch size: {batch_size}")
+                    print(f"\nSuccess with batch size: {batch_size}")
                     return result, batch_size
                 except RuntimeError as e:
                     if 'out of memory' in str(e).lower():
-                        print(f"OOM at batch size {batch_size}, trying smaller...")
+                        print(f"\nOOM at batch size {batch_size}, trying smaller...")
                         torch.cuda.empty_cache()
                         batch_size //= 2
                     else:
                         raise e
-            raise RuntimeError(f"All batch sizes down to {min_batch_size} caused OOM.")
+            raise RuntimeError(f"\nAll batch sizes down to {min_batch_size} caused OOM.")
         return wrapper
     return decorator


### PR DESCRIPTION
Add a simple auto batch size mechanism.

Start with a high batch size (now set to 128, but we can change this if needed). Try to run inference, and lower the batch size when OOM occurs. Repeat until inference succeeds. 

After a succesful run, the used batch size is stored, so that the next run with the same k-value can directly use this batch size.